### PR TITLE
Initial OpenDDS v3.14 changes

### DIFF
--- a/Build/build.cmd
+++ b/Build/build.cmd
@@ -7,20 +7,20 @@ IF EXIST "..\ext" (
     rmdir ..\ext /s /q    
 )
 
-REM Checkout OpenDDS to the version 3.13.2
-TITLE Checkout OpenDDS to the version 3.13.2
+REM Checkout OpenDDS to the version 3.14
+TITLE Checkout OpenDDS to the version 3.14
 mkdir ..\ext
 cd ..\ext
 git clone git://github.com/objectcomputing/OpenDDS.git
 cd OpenDDS
 git fetch && git fetch --tags
-git checkout tags/DDS-3.13.2
+git checkout tags/DDS-3.14
 
 REM Apply the needed OpenDDS patches
-TITLE Apply the needed OpenDDS patches
-git apply %CD%\..\..\Patches\ConditionImpl.h.patch
-git apply %CD%\..\..\Patches\DataReaderImpl.cpp.patch
-git apply %CD%\..\..\Patches\DataReaderImpl.h.patch
+REM TITLE Apply the needed OpenDDS patches
+REM git apply %CD%\..\..\Patches\ConditionImpl.h.patch
+REM git apply %CD%\..\..\Patches\DataReaderImpl.cpp.patch
+REM git apply %CD%\..\..\Patches\DataReaderImpl.h.patch
     
 REM Download ACE/TAO and unzip
 TITLE Download ACE/TAO and unzip

--- a/OpenDDSharp/OpenDDSharp.IdlGenerator/NativeIdlProject.vcxproj
+++ b/OpenDDSharp/OpenDDSharp.IdlGenerator/NativeIdlProject.vcxproj
@@ -204,10 +204,10 @@
   </ItemGroup>
   <Target Name="OpenDDSIdl" BeforeTargets="PreBuildEvent">
     <Message Text="Generating %(IdlFiles.Identity) code..." Importance="High" />
-    <Exec Command="cmd /c &quot;$(ACE_ROOT)\bin\tao_idl -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h -I$(TAO_ROOT) -Sa -St -I$(DDS_ROOT) -Wb,export_macro=%(IdlFiles.Filename)IDL_Export -Wb,export_include=%(IdlFiles.Filename)IDL_Export.h &quot;%(IdlFiles.Identity)&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />
-    <Exec Command="cmd /c &quot;$(DDS_ROOT)\bin\opendds_idl -Sa -St -Wb,export_macro=%(IdlFiles.Filename)IDL_Export &quot;%(IdlFiles.Identity)&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />    
+    <Exec Command="cmd /c &quot;$(ACE_ROOT)\bin\tao_idl --idl-version 4 -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h -I$(TAO_ROOT) -Sa -St -I$(DDS_ROOT) -Wb,export_macro=%(IdlFiles.Filename)IDL_Export -Wb,export_include=%(IdlFiles.Filename)IDL_Export.h &quot;%(IdlFiles.Identity)&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />
+    <Exec Command="cmd /c &quot;$(DDS_ROOT)\bin\opendds_idl --idl-version 4 -Sa -St -Wb,export_macro=%(IdlFiles.Filename)IDL_Export &quot;%(IdlFiles.Identity)&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />    
     <Exec Command="cmd /c &quot;$(ACE_ROOT)\bin\export_file_generator.exe&quot; %(IdlFiles.Filename)IDL &gt; %(IdlFiles.Filename)IDL_Export.h" IgnoreExitCode="false" ContinueOnError="false" />
-    <Exec Command="cmd /c &quot;$(ACE_ROOT)\bin\tao_idl -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h -I$(TAO_ROOT) -Sa -St -I$(DDS_ROOT) -Wb,export_macro=%(IdlFiles.Filename)IDL_Export -Wb,export_include=%(IdlFiles.Filename)IDL_Export.h &quot;%(IdlFiles.Filename)TypeSupport.idl&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />
+    <Exec Command="cmd /c &quot;$(ACE_ROOT)\bin\tao_idl --idl-version 4 -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h -I$(TAO_ROOT) -Sa -St -I$(DDS_ROOT) -Wb,export_macro=%(IdlFiles.Filename)IDL_Export -Wb,export_include=%(IdlFiles.Filename)IDL_Export.h &quot;%(IdlFiles.Filename)TypeSupport.idl&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />
   </Target> 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/OpenDDSharp/OpenDDSharp.IdlGenerator/OpenDDSharp.IdlGenerator.targets
+++ b/OpenDDSharp/OpenDDSharp.IdlGenerator/OpenDDSharp.IdlGenerator.targets
@@ -24,7 +24,7 @@
   </Target>
   <Target Name="OpenDDSharpIdl" BeforeTargets="PreBuildEvent">
     <Message Text="Generating %(IdlFiles.Identity) code..." Importance="High" />
-    <Exec Command="$(MSBuildThisFileDirectory)..\tools\openddsharp_idl.exe &quot;%(IdlFiles.Identity)&quot;" IgnoreExitCode="false" ContinueOnError="false" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)..\tools\openddsharp_idl.exe --idl-version 4 &quot;%(IdlFiles.Identity)&quot;&quot;" IgnoreExitCode="false" ContinueOnError="false" />
   </Target>
   <ItemGroup Condition="'$(Language)' == 'C++'">
     <Reference Include="OpenDDSharp.dll" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/OpenDDSharp/OpenDDSharp.IdlGenerator/be_init.cpp
+++ b/OpenDDSharp/OpenDDSharp.IdlGenerator/be_init.cpp
@@ -27,12 +27,21 @@ int
 BE_init(int&, ACE_TCHAR*[])
 {	
 	ACE_NEW_RETURN(be_global, BE_GlobalData, -1);
+	idl_global->default_idl_version_ = IDL_VERSION_4;
+	idl_global->anon_type_diagnostic(IDL_GlobalData::ANON_TYPE_SILENT);
 	return 0;
 }
 
 void
 BE_post_init(char*[], long)
 {	
+  if (idl_global->idl_version_ < IDL_VERSION_4) {
+    idl_global->ignore_files_ = true; // Exit without parsing files
+	ACE_DEBUG((LM_DEBUG, ACE_TEXT("OpenDDS requires IDL version to be 4 or greater\n")));
+  } else {
+    DRV_cpp_putarg("-D__OPENDDS_IDL_HAS_ANNOTATIONS");
+    idl_global->unknown_annotations_ = IDL_GlobalData::UNKNOWN_ANNOTATIONS_IGNORE;
+
 	std::ostringstream version;
 	version << "-D__OPENDDS_IDL=0x"
 		<< std::setw(2) << std::setfill('0') << DDS_MAJOR_VERSION
@@ -55,4 +64,5 @@ BE_post_init(char*[], long)
 		ACE_CString included;
 		DRV_add_include_path(included, dds_root.c_str(), 0, true);
 	}
+  }
 }

--- a/OpenDDSharp/OpenDDSharp.UnitTest/packages.config
+++ b/OpenDDSharp/OpenDDSharp.UnitTest/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.QualityTools.UnitTestFramework.Updated" version="15.0.26228" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net461" />
 </packages>

--- a/OpenDDSharp/OpenDDSharp/MulticastInst.cpp
+++ b/OpenDDSharp/OpenDDSharp/MulticastInst.cpp
@@ -91,19 +91,23 @@ void OpenDDSharp::OpenDDS::DCPS::MulticastInst::SynBackoff::set(System::Double v
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::MulticastInst::SynInterval::get() {
-    return impl_entity->syn_interval_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->syn_timeout_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::MulticastInst::SynInterval::set(OpenDDSharp::TimeValue value) {
-    impl_entity->syn_interval_ = value;
+	impl_entity->syn_interval_ = value.MicroSeconds / 1e6;
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::MulticastInst::SynTimeout::get() {
-    return impl_entity->syn_timeout_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->syn_timeout_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::MulticastInst::SynTimeout::set(OpenDDSharp::TimeValue value) {
-    impl_entity->syn_timeout_ = value;
+	impl_entity->syn_timeout_ = value.MicroSeconds / 1e6;
 };
 
 size_t OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakDepth::get() {
@@ -115,11 +119,13 @@ void OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakDepth::set(size_t value) {
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakInterval::get() {
-    return impl_entity->nak_interval_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->nak_interval_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakInterval::set(OpenDDSharp::TimeValue value) {
-    impl_entity->nak_interval_ = value;
+	impl_entity->nak_interval_ = value.MicroSeconds / 1e6;
 };
 
 size_t OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakDelayIntervals::get() {
@@ -139,11 +145,13 @@ void OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakMax::set(size_t value) {
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakTimeout::get() {
-    return impl_entity->nak_timeout_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->nak_timeout_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::MulticastInst::NakTimeout::set(OpenDDSharp::TimeValue value) {
-    impl_entity->nak_timeout_ = value;
+	impl_entity->nak_timeout_ = value.MicroSeconds / 1e6;
 };
 
 System::Byte OpenDDSharp::OpenDDS::DCPS::MulticastInst::Ttl::get() {

--- a/OpenDDSharp/OpenDDSharp/RtpsDiscovery.cpp
+++ b/OpenDDSharp/OpenDDSharp/RtpsDiscovery.cpp
@@ -30,11 +30,14 @@ OpenDDSharp::OpenDDS::RTPS::RtpsDiscovery::RtpsDiscovery(System::String^ name) :
 }
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::RTPS::RtpsDiscovery::ResendPeriod::get() {
-    return impl_entity->resend_period();
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->resend_period().value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::RTPS::RtpsDiscovery::ResendPeriod::set(OpenDDSharp::TimeValue value) {
-    impl_entity->resend_period(value);
+	::OpenDDS::DCPS::TimeDuration duration = ::OpenDDS::DCPS::TimeDuration(value.MicroSeconds / 1e6);
+	impl_entity->resend_period(duration);
 };
 
 System::UInt16 OpenDDSharp::OpenDDS::RTPS::RtpsDiscovery::PB::get() {

--- a/OpenDDSharp/OpenDDSharp/RtpsUdpInst.cpp
+++ b/OpenDDSharp/OpenDDSharp/RtpsUdpInst.cpp
@@ -60,43 +60,53 @@ void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::NakDepth::set(size_t value) {
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::NakResponseDelay::get() {
-    return impl_entity->nak_response_delay_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->nak_response_delay_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::NakResponseDelay::set(OpenDDSharp::TimeValue value) {
-    impl_entity->nak_response_delay_ = value;
+	impl_entity->nak_response_delay_ = value.MicroSeconds / 1e6;
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HeartbeatPeriod::get() {
-    return impl_entity->heartbeat_period_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->heartbeat_period_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HeartbeatPeriod::set(OpenDDSharp::TimeValue value) {
-    impl_entity->heartbeat_period_ = value;
+	impl_entity->heartbeat_period_ = value.MicroSeconds / 1e6;
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HeartbeatResponseDelay::get() {
-    return impl_entity->heartbeat_response_delay_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->heartbeat_response_delay_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HeartbeatResponseDelay::set(OpenDDSharp::TimeValue value) {
-    impl_entity->heartbeat_response_delay_ = value;
+	impl_entity->heartbeat_response_delay_ = value.MicroSeconds / 1e6;
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HandshakeTimeout::get() {
-    return impl_entity->handshake_timeout_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->handshake_timeout_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::HandshakeTimeout::set(OpenDDSharp::TimeValue value) {
-    impl_entity->handshake_timeout_ = value;
+	impl_entity->handshake_timeout_ = value.MicroSeconds / 1e6;
 };
 
 OpenDDSharp::TimeValue OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::DurableDataTimeout::get() {
-    return impl_entity->durable_data_timeout_;
+	OpenDDSharp::TimeValue timeValue = OpenDDSharp::TimeValue();
+	timeValue.MicroSeconds = impl_entity->durable_data_timeout_.value().get_msec();
+	return timeValue;
 };
 
 void OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::DurableDataTimeout::set(OpenDDSharp::TimeValue value) {
-    impl_entity->durable_data_timeout_ = value;
+	impl_entity->durable_data_timeout_ = value.MicroSeconds / 1e6;
 };
 
 System::Boolean OpenDDSharp::OpenDDS::DCPS::RtpsUdpInst::UseMulticast::get() {

--- a/OpenDDSharp/TestIdl/Test.idl
+++ b/OpenDDSharp/TestIdl/Test.idl
@@ -15,7 +15,7 @@ module Test {
         SubscriptionReconnectedTest
     };
 
-	#pragma DCPS_DATA_TYPE "Test::BasicTestStruct"    
+	@topic
 	struct BasicTestStruct {
 		long Id;
 	};
@@ -33,10 +33,9 @@ module Test {
     const long TEST_CONST = 1;
 	const string TEST_STRING_CONST = "Hello, I love you, won't you tell me your name?";
     
-	#pragma DCPS_DATA_TYPE "Test::TestStruct"
-	#pragma DCPS_DATA_KEY "Test::TestStruct Id"
+	@topic
     struct TestStruct {
-		long Id;
+		@key long Id;
 		string RawData;
 		long long TimeTicks;
         char CharType;
@@ -63,30 +62,27 @@ module Test {
         PrimitiveEnum TestEnum;
 	};
 
-	#pragma DCPS_DATA_TYPE "Test::Athlete"    
-	#pragma DCPS_DATA_KEY "Test::Athlete AthleteId"
+	@topic
 	struct Athlete
 	{
-		long AthleteId;
+		@key long AthleteId;
 		string FirstName;
 		string SecondName;
 		string Country;
 	};
 
-	#pragma DCPS_DATA_TYPE "Test::Result"
-	#pragma DCPS_DATA_KEY "Test::Result AthleteId"
+	@topic
 	struct Result
 	{				
-		long AthleteId;
+		@key long AthleteId;
 		long Rank;
 		float Score;		
 	};
 
-	#pragma DCPS_DATA_TYPE "Test::AthleteResult"    
-	#pragma DCPS_DATA_KEY "Test::AthleteResult AthleteId"
+	@topic
 	struct AthleteResult
 	{
-		long AthleteId;
+		@key long AthleteId;
 		string FirstName;
 		string SecondName;
 		string Country;

--- a/OpenDDSharp/TestIdl/TestIdl.vcxproj
+++ b/OpenDDSharp/TestIdl/TestIdl.vcxproj
@@ -233,7 +233,7 @@
   </Target>
   <Target Name="OpenDDSharpIdl" BeforeTargets="PreBuildEvent">
     <Message Text="Generating %(IdlFiles.Identity) code..." Importance="High" />
-    <Exec Command="$(MSBuildThisFileDirectory)..\OpenDDSharp.IdlGenerator\bin\$(Platform)\$(Configuration)\openddsharp_idl.exe &quot;%(IdlFiles.Identity)&quot;" IgnoreExitCode="false" ContinueOnError="false" />
+    <Exec Command="$(MSBuildThisFileDirectory)..\OpenDDSharp.IdlGenerator\bin\$(Platform)\$(Configuration)\openddsharp_idl.exe --idl-version 4 &quot;%(IdlFiles.Identity)&quot;" IgnoreExitCode="false" ContinueOnError="false" />
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Modified OpenDDSharp to use OpenDDS v3.14.  There are still some issues with generating the type support files from Test.idl, which is causing build failures.